### PR TITLE
docs: update publishing guides and add lifecycle hooks

### DIFF
--- a/docs/extensions/entry-context.md
+++ b/docs/extensions/entry-context.md
@@ -27,6 +27,7 @@ It is instantiated by Xed-Editor when the extension is loaded.
 class Main(context: ExtensionContext) : ExtensionAPI(context) {
     override fun onExtensionLoaded() {}
     override fun onUninstalled() {}
+    override fun onUpdated() {}
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
     override fun onActivityResumed(activity: Activity) {}

--- a/docs/extensions/lifecycle-hooks.md
+++ b/docs/extensions/lifecycle-hooks.md
@@ -28,8 +28,9 @@ Ignore the annotations and the context parameter for now. This will be covered o
 @Keep
 @Suppress("unused")
 class Main(context: ExtensionContext) : ExtensionAPI(context) {
-    override fun onExtensionLoaded() {} // [!code focus:7]
+    override fun onExtensionLoaded() {} // [!code focus:8]
     override fun onUninstalled() {}
+    override fun onUpdated() {}
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
     override fun onActivityResumed(activity: Activity) {}
@@ -46,10 +47,16 @@ All lifecycle methods must be overridden in your entry class. The implementation
 |-----------------------|---------------------------------|----------------------------------------------------------------------------|
 | `onExtensionLoaded`   | Extension is loaded into memory | Primary initialization (register commands, load state)                     |
 | `onUninstalled`       | Extension is removed            | Final cleanup (remove cached files)                                        |
+| `onUpdated`           | Extension is updated            | Full teardown of all previously registered services before reload          |
 | `onActivityCreated`   | Activity is created             | React to UI being created (e.g. terminal/editor opened, initialize panels) |
 | `onActivityResumed`   | App enters foreground           | Resume active work (refresh UI overlays, continue polling)                 |
 | `onActivityPaused`    | App goes to background          | Pause ongoing work (stop polling, save state, pause animations or updates) |
 | `onActivityDestroyed` | Activity is destroyed           | Cleanup UI-related resources, unregister receivers                         |
+
+> [!IMPORTANT]
+> `onUpdated()` is invoked before the new extension version is loaded, meaning it runs on the old
+instance. It must therefore fully clean up all previously registered services (language servers,
+runners, commands, listeners, etc.) to prevent duplication when the new version is initialized.
 
 ## `onExtensionLoaded()` vs `onActivityCreated()`
 

--- a/docs/extensions/manifest-file.md
+++ b/docs/extensions/manifest-file.md
@@ -5,10 +5,13 @@ navTitle: Manifest File
 
 # Configure Your Extension Metadata
 
-Before you build, you must update the core metadata within the `manifest.json` file located in the root of the project directory.
+Before you build, you must update the core metadata within the `manifest.json` file located in the
+root of the project directory.
 
 ## Example
-Below, you can see what a `manifest.json` file might look like, using a Git blame viewer extension as an example.
+
+Below, you can see what a `manifest.json` file might look like, using a Git blame viewer extension
+as an example.
 
 ```json
 {
@@ -25,7 +28,12 @@ Below, you can see what a `manifest.json` file might look like, using a Git blam
   "targetAppVersion": 87,
   "repository": "https://github.com/Xed-Editor/xed-git-blame-viewer",
   "license": "MIT",
-  "tags": ["git", "blame", "vsc", "editor"],
+  "tags": [
+    "git",
+    "blame",
+    "vsc",
+    "editor"
+  ],
   "hasSettings": true
 }
 ```
@@ -47,12 +55,16 @@ Below, you can see what a `manifest.json` file might look like, using a Git blam
 | `tags`          | No       | string[]        | Optional tags to categorize the extension.                                                                                                                                                                                  |
 | `hasSettings`   | No       | boolean         | Indicates whether the extension provides a [settings UI](/docs/extensions/settings) inside Xed-Editor.<br>If it's set to true, a settings icon will show in the extension's detail page.<br>Default is `false`.             |
 
+We recommend setting a `minAppVersion` to avoid requiring users to install the extension when it is
+already certain that it will not work on the device.
+
 You can find the version code of your Xed-Editor installation under
 `Settings > About > Version code`.
 
 > [!WARNING]
-> If two extensions have the same `id`, only one will load (usually the first one found). Use your domain or GitHub username to avoid collisions.
+> If two extensions have the same `id`, only one will load (usually the first one found). Use your
+> domain or GitHub username to avoid collisions.
 
 > [!NOTE]
-> Use **semantic versioning for `version`**
-> Xed-Editor may offer auto-updates in the future.
+> Use semantic versioning for the `version` property. Before every release, you must increment the
+> version number. Otherwise, users will not be able to update the extension.

--- a/docs/extensions/publishing.md
+++ b/docs/extensions/publishing.md
@@ -5,16 +5,15 @@ navTitle: Publishing
 
 # Publishing Your Extension
 
-Xed-Editor does **not** yet have an automated publishing system.
+To publish an extension, you first need to create an account on https://xed-editor.app.
 
-**Announce your extension**
-Post it in the official community channels (**DO NOT SPAM**):
-- [Discord](https://discord.gg/6bKzcQRuef)
-- [Telegram](https://t.me/XedEditor)
-- [GitHub Discussions](https://github.com/Xed-Editor/Xed-Editor/discussions)
+## Upload
+Once you are signed in, go to the extensions page at https://xed-editor.app/extensions. There you will find a **`Publish`** button.
+Click it and upload your extension by dragging and dropping the ZIP file of your release into the
+upload area.
 
-### Future plans
-
-An official extension repository with browse, search and auto-update support is planned.
-
-Until then, GitHub Releases and community announcement is the recommended distribution method.
+## Update
+After publishing, updates are handled in the same way. You simply create a new release ZIP and
+upload it again through the same page. As long as the extension ID stays the same and you increase
+the version number in your manifest, users will be able to receive the update automatically and update
+to the latest version without any extra steps.

--- a/docs/icon-packs/index.md
+++ b/docs/icon-packs/index.md
@@ -149,8 +149,8 @@ Example:
 
 ```json
 "folderNames": {
-"rust": "icons/folder-rust.svg",
-"assets": "icons/folder-assets.svg"
+  "rust": "icons/folder-rust.svg",
+  "assets": "icons/folder-assets.svg"
 }
 ```
 
@@ -160,8 +160,8 @@ Maps specific folder names of expanded folders to custom icons.
 
 ```json
 "folderNamesExpanded": {
-"rust": "icons/folder-rust-open.svg",
-"assets": "icons/folder-assets-open.svg"
+  "rust": "icons/folder-rust-open.svg",
+  "assets": "icons/folder-assets-open.svg"
 }
 ```
 
@@ -171,8 +171,8 @@ Maps exact file names to icons.
 
 ```json
 "fileNames": {
-"readme.md": "icons/readme.svg",
-"package.json": "icons/node.svg"
+  "readme.md": "icons/readme.svg",
+  "package.json": "icons/node.svg"
 }
 ```
 
@@ -182,8 +182,8 @@ Maps file extensions to icons.
 
 ```json
 "fileExtensions": {
-"ts": "icons/typescript.svg",
-"js": "icons/javascript.svg"
+  "ts": "icons/typescript.svg",
+  "js": "icons/javascript.svg"
 }
 ```
 
@@ -197,10 +197,10 @@ These identifiers are lowercase and include both built-in and extension-defined 
 
 ```json
 "languageNames": {
-"javascript": "icons/javascript.svg",
-"typescript": "icons/typescript.svg",
-"python": "icons/python.svg",
-"rust": "icons/rust.svg"
+  "javascript": "icons/javascript.svg",
+  "typescript": "icons/typescript.svg",
+  "python": "icons/python.svg",
+  "rust": "icons/rust.svg"
 }
 ```
 
@@ -270,3 +270,24 @@ registry and may change at any time. For the most up-to-date information, refer 
 
 Additionally, any custom language names are possible. These will only work, however, if the
 extension that registers this file type is installed.
+
+## Publish an Icon Pack
+
+::: warning
+This feature is still under development.
+:::
+
+
+Publishing an icon pack works in a very similar way to [publishing an extension](/docs/extensions/publishing).
+
+First, you need to create an account on https://xed-editor.app.
+
+Once you are signed in, go to the icon pack page at https://xed-editor.app/icon-packs. There you will find a **`Publish`** button.
+Click it and upload your icon pack by dragging and dropping the ZIP file of your release into the upload area.
+
+Once uploaded, your icon pack will appear in the extension marketplace inside the editor. From
+there, users can browse and install it like any other extension.
+
+Updating an icon pack follows the same rule as extensions. You just upload a new ZIP file with an
+increased version number while keeping the same ID. This ensures that users can receive updates
+automatically without needing to reinstall anything manually.

--- a/docs/lsp/builtin-servers.md
+++ b/docs/lsp/builtin-servers.md
@@ -32,7 +32,7 @@ The integrated language servers should work without any problems. If you do enco
 
 Xed-Editor ships with built-in servers for many common programming languages, including:
 
-- **Python**: [`python-lsp-server`](https://github.com/python-lsp/python-lsp-server)
+- **Python**: [`pyright`](https://github.com/microsoft/pyright)
 - **JavaScript & TypeScript**: [`typescript-language-server`](https://github.com/typescript-language-server/typescript-language-server)
 - **HTML, CSS, JSON**: [`vscode-langservers-extracted`](https://github.com/hrsh7th/vscode-langservers-extracted)
 - **Emmet**: [`emmet-language-server`](https://github.com/olrtg/emmet-language-server)

--- a/docs/lsp/report-issues.md
+++ b/docs/lsp/report-issues.md
@@ -43,6 +43,9 @@ In the top-right corner of the log page, click the **Report issue** button.
 This will automatically open a GitHub issue template where you can submit the problem. The report
 helps us analyze and fix the issue more effectively.
 
+> [!NOTE]
+> If the logs are too long, this button copies them to your clipboard instead, and you must manually paste them into the newly opened GitHub issue window.
+
 ## When no clear error is visible
 
 If you cannot find any instance marked as error or crash, check all available instances for unusual

--- a/docs/themes/index.md
+++ b/docs/themes/index.md
@@ -319,10 +319,10 @@ colors. Example:
 
 ```json
 "tokenColors": {
-"comment": "#6A9955",
-"string": "#CE9178",
-"keyword": "#569CD6",
-"function": "#DCDCAA"
+  "comment": "#6A9955",
+  "string": "#CE9178",
+  "keyword": "#569CD6",
+  "function": "#DCDCAA"
 }
 ```
 
@@ -337,22 +337,42 @@ Example:
 
 ```json
 "tokenColors": [
-{
-"scope": "comment",
-"settings": {
-"foreground": "#6A9955",
-"fontStyle": "italic"
-}
-},
-{
-"scope": "string",
-"settings": {
-"foreground": "#CE9178"
-}
-}
+  {
+    "scope": "comment",
+    "settings": {
+      "foreground": "#6A9955",
+      "fontStyle": "italic"
+    }
+  },
+  {
+    "scope": "string",
+    "settings": {
+      "foreground": "#CE9178"
+    }
+  }
 ]
 ```
 
 The `scope` property defines which syntax elements the rule applies to, and the `settings` property
 contains the color settings for that scope. Colors values have to be in the hex color format (
 `#RRGGBB` or `#RRGGBBAA`). Optionally color names can be used (e.g., `red`, `blue`, etc.).
+
+## Publish a Theme
+
+::: warning
+This feature is still under development.
+:::
+
+Publishing a theme works in a very similar way to [publishing an extension](/docs/extensions/publishing).
+
+First, you need to create an account on https://xed-editor.app.
+
+Once you are signed in, go to the theme page at https://xed-editor.app/themes. There you will find a **`Publish`** button.
+Click it and upload your theme by dragging and dropping the JSON manifest file into the upload area.
+
+Once uploaded, your theme will appear in the extension marketplace inside the editor. From
+there, users can browse and install it like any other extension.
+
+Updating a theme follows the same rule as extensions. You just upload a new JSON file with an
+increased version number while keeping the same ID. This ensures that users can receive updates
+automatically without needing to reinstall anything manually.


### PR DESCRIPTION
- Update extension, icon pack, and theme documentation to reflect the new publishing process via xed-editor.app.
- Add documentation for the `onUpdated()` lifecycle hook in `ExtensionAPI` and provide guidance on cleaning up services during updates.
- Update the manifest guide with recommendations for `minAppVersion` and strict versioning requirements for updates.
- Add a note to the LSP issue reporting guide regarding clipboard behavior for large log files.
- Improve code block formatting and indentation in JSON examples across multiple guides.